### PR TITLE
(feat) Add Variant#id accessior and Variant.idof<T>()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ assert(!vStr.is<f64>())           // ok
 assert(vStr.is<string>())         // ok
 assert(vFoo.is<Foo>())            // ok
 
+assert(vNum.id != vStr.id)        // compare dynamic IDs
+
 let valF64   = vNum.get<f64>()    // safely extract value
 let willFail = vNum.get<string>() // will throw exception!
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ assert(!vStr.is<f64>())           // ok
 assert(vStr.is<string>())         // ok
 assert(vFoo.is<Foo>())            // ok
 
-assert(vNum.id != vStr.id)        // compare dynamic IDs
+assert(vNum.id != vStr.id)        // compare dynamic IDs.
+assert(vFoo.id == Variant.idof<Foo>())
 
 let valF64   = vNum.get<f64>()    // safely extract value
 let willFail = vNum.get<string>() // will throw exception!

--- a/assembly/__tests__/basic.spec.ts
+++ b/assembly/__tests__/basic.spec.ts
@@ -68,10 +68,10 @@ describe("Variant/id", () => {
     let _u8  = Variant.from<u8>(3);
     let _i32  = Variant.from(123);
     let _foo  = Variant.from(new Foo);
-    expect(_bool.id).toBe(0);
-    expect(_i32.id).toBe(3);
-    expect(_u8.id).toBe(5);
-    expect(_foo.id).toBe(12 + idof<Foo>());
+    expect(_bool.id).toBe(Variant.idof<bool>());
+    expect(_i32.id).toBe(Variant.idof<i32>());
+    expect(_u8.id).toBe(Variant.idof<u8>());
+    expect(_foo.id).toBe(Variant.idof<Foo>());
   });
 });
 

--- a/assembly/__tests__/basic.spec.ts
+++ b/assembly/__tests__/basic.spec.ts
@@ -1,5 +1,7 @@
 import { Variant } from "../index";
 
+class Foo {}
+
 describe("Variant/from, Variant/is, Variant/get", () => {
   it("should init as i32 type", () => {
     let val = Variant.from(123);
@@ -57,6 +59,19 @@ describe("Variant/from, Variant/is, Variant/get", () => {
     let val = Variant.from(Variant.from(123));
     expect(val.is<Variant>()).toBe(true);
     expect(val.get<Variant>().get<i32>()).toBe(123);
+  });
+});
+
+describe("Variant/id", () => {
+  it("should get ids", () => {
+    let _bool = Variant.from(true);
+    let _u8  = Variant.from<u8>(3);
+    let _i32  = Variant.from(123);
+    let _foo  = Variant.from(new Foo);
+    expect(_bool.id).toBe(0);
+    expect(_i32.id).toBe(3);
+    expect(_u8.id).toBe(5);
+    expect(_foo.id).toBe(12 + idof<Foo>());
   });
 });
 

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -45,6 +45,10 @@ export class Variant {
 
   private constructor() { unreachable(); }
 
+  @inline get id(): i32 {
+    return this.discriminator;
+  }
+
   @inline set<T>(value: T): void {
     this.discriminator = DISCRIMINATOR<T>();
     store<T>(changetype<usize>(this), value, STORAGE);

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -40,6 +40,10 @@ export class Variant {
     return out;
   }
 
+  @inline static idof<T>(): i32 {
+    return DISCRIMINATOR<T>();
+  }
+
   private discriminator: i32;
   private storage: u64;
 


### PR DESCRIPTION
Add new methods:
```ts
Variant#id
Variant.idof<T>()
```