### PR TITLE
fix: value is used before being assigned

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -12,7 +12,7 @@ const enum Discriminator {
 function DISCRIMINATOR<T>(): Discriminator {
   if (isManaged<T>())   return Discriminator.ManagedRef + idof<T>();
   if (isReference<T>()) return Discriminator.UnmanagedRef;
-  let value!: T;
+  const value: T = 0;
   if (value instanceof bool) return Discriminator.Bool;
   if (value instanceof i8)   return Discriminator.I8;
   if (value instanceof i16)  return Discriminator.I16;


### PR DESCRIPTION
At https://github.com/MaxGraey/as-variant/blob/main/assembly/index.ts#L15, `value` is not assigned before being used. This used to work in `<0.21.x`, but fails on recent versions. All primitives will fail.

```js
const foo = Variant.from<f32>(3.14);
foo.get<f32>();
// FAIL
```

We know that it is a primitive because of the previous `isManaged<T>()` and `isReference<T>()` checks, so `const value:T = 0;` is valid here.

This PR fixes the issue